### PR TITLE
Bugfix: offline computers are no longer shown as online

### DIFF
--- a/src/components/DeviceCard.svelte
+++ b/src/components/DeviceCard.svelte
@@ -13,8 +13,12 @@
   import relativeTime from "dayjs/plugin/relativeTime";
   dayjs.extend(relativeTime);
 
-  $: online = device.meta.ips && device.meta.ips.length > 0;
   $: seen = device.meta.seen && dayjs(device.meta.seen);
+
+  // this subtracts the current UNIX-timestamp from the UNIX-timestamp of last seen
+  // the result will be 'seen from now' in seconds which is then compared to three minutes
+  // hence a computer is marked as offline if it hasn't been seen for three minutes
+  $: online = (seen) ? ((dayjs().unix() - seen.unix()) < 180) : false;
 
   let isWaking = false;
   function doWake() {


### PR DESCRIPTION
The original version looks if the IP address of a computer has been stored in order to determine whether it is shown as online or not.  This IP address seems not to be removed when a computer is offline. At my place this led to the behaviour that offline computers were shown as 'online', although they haven't been seen for weeks.

As the 'last seen' value of a computer was correct, I implemented a quick fix for the described problem. It checks if the 'last seen' value is older than three minutes, the computer will then be shown as offline. Else it will be marked as online.